### PR TITLE
refactor(stock_quant_history): Invert snapshot logic to use allowed l…

### DIFF
--- a/stock_quant_history/models/stock_quant_history_snapshot.py
+++ b/stock_quant_history/models/stock_quant_history_snapshot.py
@@ -98,14 +98,12 @@ class StockQuantHistorySnapshot(models.Model):
         return domain
 
     @api.model
-    def _ignored_location_usage(self):
+    def _allowed_location_usage(self):
         """If you overwrite or change this
         list you'll probably want to regenerate all your
         snapshots"""
         return [
-            "supplier",
-            "customer",
-            "inventory",
+            "internal",
         ]
 
     def _generate_stock_quant_history(self):
@@ -161,9 +159,9 @@ class StockQuantHistorySnapshot(models.Model):
         _logger.info(
             "Apply %s stock.move.line since previous snapshot", len(stock_move_lines)
         )
-        ignored_location_usage = self._ignored_location_usage()
+        allowed_location_usage = self._allowed_location_usage()
         for move_line in stock_move_lines:
-            if move_line.location_id.usage not in ignored_location_usage:
+            if move_line.location_id.usage in allowed_location_usage:
                 quant_history[
                     (move_line.product_id, move_line.lot_id, move_line.location_id)
                 ].quantity = tools.float_round(
@@ -176,7 +174,7 @@ class StockQuantHistorySnapshot(models.Model):
                     precision_rounding=move_line.product_id.uom_id.rounding,
                 )
 
-            if move_line.location_dest_id.usage not in ignored_location_usage:
+            if move_line.location_dest_id.usage in allowed_location_usage:
                 quant_history[
                     (move_line.product_id, move_line.lot_id, move_line.location_dest_id)
                 ].quantity = tools.float_round(

--- a/stock_quant_history/models/stock_quant_history_snapshot.py
+++ b/stock_quant_history/models/stock_quant_history_snapshot.py
@@ -149,17 +149,27 @@ class StockQuantHistorySnapshot(models.Model):
                 ]
                 quant_copy.quantity = stock_quant_history.quantity
 
-        stock_move_lines = (
-            self.env["stock.move.line"]
-            .sudo()
-            .search(
-                self._prepare_stock_move_line_filter(previous_quant_snapshot),
-            )
-        )
+        allowed_location_usage = self._allowed_location_usage()
+        domain = self._prepare_stock_move_line_filter(previous_quant_snapshot)
+        if allowed_location_usage:
+            if len(allowed_location_usage) == 1:
+                operator = "="
+                usage_value = allowed_location_usage[0]
+            else:
+                operator = "in"
+                usage_value = allowed_location_usage
+
+            location_domain = [
+                "|",
+                ("location_id.usage", operator, usage_value),
+                ("location_dest_id.usage", operator, usage_value),
+            ]
+            domain = AND([domain, location_domain])
+
+        stock_move_lines = self.env["stock.move.line"].sudo().search(domain)
         _logger.info(
             "Apply %s stock.move.line since previous snapshot", len(stock_move_lines)
         )
-        allowed_location_usage = self._allowed_location_usage()
         for move_line in stock_move_lines:
             if move_line.location_id.usage in allowed_location_usage:
                 quant_history[

--- a/stock_quant_history/tests/test_stock_quant_history.py
+++ b/stock_quant_history/tests/test_stock_quant_history.py
@@ -165,8 +165,10 @@ class TestStockQuantHistory(BaseCommon):
                 [
                     (
                         "location_id.usage",
-                        "=",
-                        "internal",
+                        "in",
+                        self.env[
+                            "stock.quant.history.snapshot"
+                        ]._allowed_location_usage(),
                     ),
                 ]
             ),
@@ -335,8 +337,10 @@ class TestStockQuantHistory(BaseCommon):
                 [
                     (
                         "location_id.usage",
-                        "=",
-                        "internal",
+                        "in",
+                        self.env[
+                            "stock.quant.history.snapshot"
+                        ]._allowed_location_usage(),
                     ),
                 ]
             ),

--- a/stock_quant_history/tests/test_stock_quant_history.py
+++ b/stock_quant_history/tests/test_stock_quant_history.py
@@ -165,12 +165,8 @@ class TestStockQuantHistory(BaseCommon):
                 [
                     (
                         "location_id.usage",
-                        "not in",
-                        [
-                            "customer",
-                            "inventory",
-                            "supplier",
-                        ],
+                        "=",
+                        "internal",
                     ),
                 ]
             ),
@@ -339,12 +335,8 @@ class TestStockQuantHistory(BaseCommon):
                 [
                     (
                         "location_id.usage",
-                        "not in",
-                        [
-                            "customer",
-                            "inventory",
-                            "supplier",
-                        ],
+                        "=",
+                        "internal",
                     ),
                 ]
             ),


### PR DESCRIPTION
…ocations

The previous implementation of the stock quant history snapshot used a negative logic, ignoring a list of specified location usages. This was causing issues with virtual production locations and made the module hard to maintain.

This commit refactors the logic to be positive. Instead of ignoring locations, the logic now only includes locations with the 'internal' usage type. This simplifies the code, improves maintainability, and resolves the issue with virtual locations.

The `_ignored_location_usage` method has been renamed to `_allowed_location_usage` to better reflect its new purpose. The corresponding unit tests have also been updated to align with the new logic.